### PR TITLE
Message key name configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 sudo: false
 node_js:
-  - '6'
-  - '7'
+  - '8'
+  - '9'
 cache: yarn
 install:
   - npm i chat-engine react-native

--- a/Libraries/android/chat-engine-notifications/src/main/java/com/pubnub/cennotifications/helpers/CENNotificationsHelper.java
+++ b/Libraries/android/chat-engine-notifications/src/main/java/com/pubnub/cennotifications/helpers/CENNotificationsHelper.java
@@ -222,11 +222,11 @@ public class CENNotificationsHelper {
      * Retrieve reference on delivered notification with specific chat engine identifier.
      *
      * @param context Reference on execution context.
-     * @return Reference on notification representation instance or 'null' if notification with specified 'ceid' not
+     * @return Reference on notification representation instance or 'null' if notification with specified 'eid' not
      *         found.
      */
     @SuppressWarnings("unchecked")
-    public static CENNotification deliveredNotification(Context context, String ceid) {
+    public static CENNotification deliveredNotification(Context context, String eid) {
         List<Map<String, Object>> deliveredNotifications = deliveredNotifications(context);
         CENNotification notification = null;
 
@@ -234,10 +234,10 @@ public class CENNotificationsHelper {
             CENNotification deliveredNotification = new CENNotification(context, payload);
             Map<String, Object> cePayload = deliveredNotification.chatEnginePayload();
 
-            if (ceid != null && cePayload != null && cePayload.containsKey("ceid")) {
-                String deliveredNotificationCEId = (String) cePayload.get("ceid");
+            if (eid != null && cePayload != null && cePayload.containsKey("eid")) {
+                String deliveredNotificationEID = (String) cePayload.get("eid");
 
-                if (deliveredNotificationCEId != null && deliveredNotificationCEId.equalsIgnoreCase(ceid)) {
+                if (deliveredNotificationEID != null && deliveredNotificationEID.equalsIgnoreCase(eid)) {
                     notification = deliveredNotification;
                     break;
                 }

--- a/Libraries/android/chat-engine-notifications/src/main/java/com/pubnub/cennotifications/modules/CENNotifications.java
+++ b/Libraries/android/chat-engine-notifications/src/main/java/com/pubnub/cennotifications/modules/CENNotifications.java
@@ -32,7 +32,7 @@ public class CENNotifications extends ReactContextBaseJavaModule {
     final private static String BROADCAST_DID_REGISTER_DEVICE = "CENRegisteredForRemoteNotifications";
     final private static String JS_DID_REGISTER_DEVICE = "CENRegistered";
 
-    final private static String CHAT_ENGINE_SEEN_EVENT = "$.notifications.seen";
+    final private static String CHAT_ENGINE_SEEN_EVENT = "$notifications.seen";
     final private static String NOTIFICATION_DEFAULT_EVENT = "com.pubnub.cennotifications.default-event";
 
     /**
@@ -410,16 +410,16 @@ public class CENNotifications extends ReactContextBaseJavaModule {
         if (chatEnginePayload != null && chatEngineEvent != null && chatEngineEvent.equalsIgnoreCase(CHAT_ENGINE_SEEN_EVENT)) {
             NotificationManager notificationManager = ((NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE));
             Map cePayloadData = (Map) chatEnginePayload.get("data");
-            if (cePayloadData != null && cePayloadData.containsKey("ceid") && notificationManager != null) {
-                String ceid = (String) cePayloadData.get("ceid");
+            if (cePayloadData != null && cePayloadData.containsKey("eid") && notificationManager != null) {
+                String eid = (String) cePayloadData.get("eid");
 
-                if (ceid.equalsIgnoreCase("all")) {
+                if (eid.equalsIgnoreCase("all")) {
                     CENNotificationsHelper.Logi("CENNotifications#markNotificationAsSeen: all notifications.");
                     CENNotificationsHelper.clearDeliveredNotifications(context);
                     notificationManager.cancelAll();
                 } else {
-                    CENNotificationsHelper.Logi("CENNotifications#markNotificationAsSeen: notifications with " + ceid + " id.");
-                    CENNotification deliveredNotification = CENNotificationsHelper.deliveredNotification(context, ceid);
+                    CENNotificationsHelper.Logi("CENNotifications#markNotificationAsSeen: notifications with " + eid + " id.");
+                    CENNotification deliveredNotification = CENNotificationsHelper.deliveredNotification(context, eid);
                     if (deliveredNotification != null) {
                         CENNotificationsHelper.removeDeliveredNotification(context, deliveredNotification);
                         notificationManager.cancel(deliveredNotification.id());

--- a/Libraries/ios/CENNotifications/CENNotifications.m
+++ b/Libraries/ios/CENNotifications/CENNotifications.m
@@ -19,7 +19,7 @@ static NSString * const CENReceivedRemoteNotification = @"CENReceivedRemoteNotif
 static NSString * const CENErrorUnableToRequestPermissions = @"E_UNABLE_TO_REQUEST_PERMISSIONS";
 static NSString * const CENErrorUnableToRegisterBecauseOfUserReject = @"E_FAILED_TO_REGISTER_BECAUSE_OF_USER_REJECT";
 
-static NSString * const CENSeenEventName = @"$.notifications.seen";
+static NSString * const CENSeenEventName = @"$notifications.seen";
 
 /**
  * @brief  Stores reference on block which should be used for push notification payload pre-processing.
@@ -433,7 +433,7 @@ RCT_EXPORT_METHOD(deliveredNotifications:(RCTResponseSenderBlock)callback) {
 
     if (@available(iOS 10.0, *)) {
         NSDictionary *chatEngineNotificationPayload = notification[@"notification"][@"cepayload"];
-        NSString *targetNotificationCEID = chatEngineNotificationPayload[@"data"][@"ceid"];
+        NSString *targetNotificationEID = chatEngineNotificationPayload[@"data"][@"eid"];
         UIBackgroundTaskIdentifier backgroundTaskIdentifier = 0;
         if (CENSharedApplication().applicationState != UIApplicationStateActive) {
             backgroundTaskIdentifier = [CENSharedApplication() beginBackgroundTaskWithExpirationHandler:^{
@@ -449,11 +449,11 @@ RCT_EXPORT_METHOD(deliveredNotifications:(RCTResponseSenderBlock)callback) {
                                                         NSUInteger notificationIdx,
                                                         BOOL *notificationsEnumeratorStop) {
                 UNNotificationContent *content = deliveredNotification.request.content;
-                if (content.userInfo && content.userInfo[@"cepayload"] && content.userInfo[@"cepayload"][@"ceid"]) {
-                    if ([content.userInfo[@"cepayload"][@"ceid"] isEqualToString:targetNotificationCEID] ||
-                        [targetNotificationCEID isEqualToString:@"all"]) {
+                if (content.userInfo && content.userInfo[@"cepayload"] && content.userInfo[@"cepayload"][@"eid"]) {
+                    if ([content.userInfo[@"cepayload"][@"eid"] isEqualToString:targetNotificationEID] ||
+                        [targetNotificationEID isEqualToString:@"all"]) {
                         [notificationIdentifiers addObject:deliveredNotification.request.identifier];
-                        *notificationsEnumeratorStop = ![targetNotificationCEID isEqualToString:@"all"];
+                        *notificationsEnumeratorStop = ![targetNotificationEID isEqualToString:@"all"];
                     }
                 }
             }];
@@ -583,7 +583,7 @@ RCT_EXPORT_METHOD(receiveMissedEvents) {
         if (applicationLaunchOptions[UIApplicationLaunchOptionsRemoteNotificationKey]) {
             NSDictionary *remoteNotification = applicationLaunchOptions[UIApplicationLaunchOptionsRemoteNotificationKey];
             if (remoteNotification[@"cepayload"]) {
-                onUserAction = [remoteNotification[@"cepayload"][@"ceid"] isEqualToString:userInfo[@"cepayload"][@"ceid"]];
+                onUserAction = [remoteNotification[@"cepayload"][@"eid"] isEqualToString:userInfo[@"cepayload"][@"eid"]];
             }
         }
         NSDictionary *notification = [CENNotifications notification:userInfo

--- a/Libraries/ios/CENNotifications/Categories/RCTConvert+CENUNNotification.m
+++ b/Libraries/ios/CENNotifications/Categories/RCTConvert+CENUNNotification.m
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_END
 
     UNNotificationContent *notificationContent = notification.request.content;
     NSDictionary *notificationRepresentation = nil;
-    if (notificationContent.userInfo && notificationContent.userInfo[@"ceid"]) {
+    if (notificationContent.userInfo && notificationContent.userInfo[@"eid"]) {
         notificationRepresentation = @{
             @"date": notification.date,
             @"data": @{ @"notification": notificationContent.userInfo, @"foreground": @NO, @"userInteraction": @NO }

--- a/demo/android/chat-engine-notifications/src/main/java/com/pubnub/cennotifications/helpers/CENNotificationsHelper.java
+++ b/demo/android/chat-engine-notifications/src/main/java/com/pubnub/cennotifications/helpers/CENNotificationsHelper.java
@@ -222,11 +222,11 @@ public class CENNotificationsHelper {
      * Retrieve reference on delivered notification with specific chat engine identifier.
      *
      * @param context Reference on execution context.
-     * @return Reference on notification representation instance or 'null' if notification with specified 'ceid' not
+     * @return Reference on notification representation instance or 'null' if notification with specified 'eid' not
      *         found.
      */
     @SuppressWarnings("unchecked")
-    public static CENNotification deliveredNotification(Context context, String ceid) {
+    public static CENNotification deliveredNotification(Context context, String eid) {
         List<Map<String, Object>> deliveredNotifications = deliveredNotifications(context);
         CENNotification notification = null;
 
@@ -234,10 +234,10 @@ public class CENNotificationsHelper {
             CENNotification deliveredNotification = new CENNotification(context, payload);
             Map<String, Object> cePayload = deliveredNotification.chatEnginePayload();
 
-            if (ceid != null && cePayload != null && cePayload.containsKey("ceid")) {
-                String deliveredNotificationCEId = (String) cePayload.get("ceid");
+            if (eid != null && cePayload != null && cePayload.containsKey("eid")) {
+                String deliveredNotificationEID = (String) cePayload.get("eid");
 
-                if (deliveredNotificationCEId != null && deliveredNotificationCEId.equalsIgnoreCase(ceid)) {
+                if (deliveredNotificationEID != null && deliveredNotificationEID.equalsIgnoreCase(eid)) {
                     notification = deliveredNotification;
                     break;
                 }

--- a/demo/android/chat-engine-notifications/src/main/java/com/pubnub/cennotifications/modules/CENNotifications.java
+++ b/demo/android/chat-engine-notifications/src/main/java/com/pubnub/cennotifications/modules/CENNotifications.java
@@ -32,7 +32,7 @@ public class CENNotifications extends ReactContextBaseJavaModule {
     final private static String BROADCAST_DID_REGISTER_DEVICE = "CENRegisteredForRemoteNotifications";
     final private static String JS_DID_REGISTER_DEVICE = "CENRegistered";
 
-    final private static String CHAT_ENGINE_SEEN_EVENT = "$.notifications.seen";
+    final private static String CHAT_ENGINE_SEEN_EVENT = "$notifications.seen";
     final private static String NOTIFICATION_DEFAULT_EVENT = "com.pubnub.cennotifications.default-event";
 
     /**
@@ -410,16 +410,16 @@ public class CENNotifications extends ReactContextBaseJavaModule {
         if (chatEnginePayload != null && chatEngineEvent != null && chatEngineEvent.equalsIgnoreCase(CHAT_ENGINE_SEEN_EVENT)) {
             NotificationManager notificationManager = ((NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE));
             Map cePayloadData = (Map) chatEnginePayload.get("data");
-            if (cePayloadData != null && cePayloadData.containsKey("ceid") && notificationManager != null) {
-                String ceid = (String) cePayloadData.get("ceid");
+            if (cePayloadData != null && cePayloadData.containsKey("eid") && notificationManager != null) {
+                String eid = (String) cePayloadData.get("eid");
 
-                if (ceid.equalsIgnoreCase("all")) {
+                if (eid.equalsIgnoreCase("all")) {
                     CENNotificationsHelper.Logi("CENNotifications#markNotificationAsSeen: all notifications.");
                     CENNotificationsHelper.clearDeliveredNotifications(context);
                     notificationManager.cancelAll();
                 } else {
-                    CENNotificationsHelper.Logi("CENNotifications#markNotificationAsSeen: notifications with " + ceid + " id.");
-                    CENNotification deliveredNotification = CENNotificationsHelper.deliveredNotification(context, ceid);
+                    CENNotificationsHelper.Logi("CENNotifications#markNotificationAsSeen: notifications with " + eid + " id.");
+                    CENNotification deliveredNotification = CENNotificationsHelper.deliveredNotification(context, eid);
                     if (deliveredNotification != null) {
                         CENNotificationsHelper.removeDeliveredNotification(context, deliveredNotification);
                         notificationManager.cancel(deliveredNotification.id());

--- a/demo/src/screens/chats-list.js
+++ b/demo/src/screens/chats-list.js
@@ -105,7 +105,7 @@ export default class CEPNChatsListView extends React.Component {
      */
     onChatEngineReady() {
         this.setState({ username: CEPNChatsListView.ChatEngine.me.uuid });
-        CEPNChatsListView.ChatEngine.me.notifications.on('$.notifications.received', this._onNotification);
+        CEPNChatsListView.ChatEngine.me.notifications.on('$notifications.received', this._onNotification);
         CEPNChatsListView.ChatEngine.me.notifications.registerNotificationActions({ Accept: 'default', Reject: 'none' });
         CEPNChatsListView.ChatEngine.me.notifications.registerNotificationChannels([
             { id: 'cennotifications', name: 'CENNotifications Channel' }

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -3,7 +3,7 @@ import eslint from 'gulp-eslint';
 import runSequence from 'run-sequence';
 import shell from 'gulp-shell';
 
-gulp.task('integration_test', shell.task('npm run integrationTest'));
+gulp.task('integration_test', shell.task('npm run integration_test'));
 gulp.task('unit_tests', shell.task('npm run unit_test'));
 gulp.task('full_test', shell.task('npm run test'));
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "uuid": "^3.2.1"
   },
   "devDependencies": {
+    "babel-core": "^6.26.3",
+    "babel-jest": "^23.4.2",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-builtin-extend": "1.x.x",
     "babel-preset-env": "1.x.x",

--- a/src/components/extension.js
+++ b/src/components/extension.js
@@ -369,6 +369,7 @@ export class CENotificationsExtension extends ChatEnginePlugin {
         if (formatterProvided) {
             formattedPayload = this.configuration.formatter(payload);
         }
+
         if (!formatterProvided || (formatterProvided && formattedPayload === null)) {
             let nativePayload = {
                 event,
@@ -522,6 +523,11 @@ export class CENotificationsExtension extends ChatEnginePlugin {
         if (!TypeValidator.isDefined(configuration.markAsSeen)) {
             configuration.markAsSeen = false;
         }
+
+        if (!TypeValidator.isDefined(configuration.messageKey)) {
+            configuration.messageKey = 'message';
+        }
+
         // Add additional channel for exclusion. There is no use for remote users to receive messages for local user activity as notifications.
         configuration.ignoredChats = configuration.ignoredChats || [];
         if (!configuration.ignoredChats.includes('#read.#feed')) {

--- a/src/components/extension.js
+++ b/src/components/extension.js
@@ -50,13 +50,13 @@ export class CENotificationsExtension extends ChatEnginePlugin {
      * Create and configure {@link ChatEngine} plugin to work with push notifications.
      *
      * @param {!CEConfiguration} configuration - Push notification registration/handling options.
-     * @listens {$.notifications.registered} listen event to start push notification management for chat which requested it.
-     * @listens {$.notifications.received} listen event to mark received notification as `seen` (if `configuration.markAsSeen` is set to `true`).
-     * @listens {$.created.chat} listen event to enable push notifications on just created chat if it explicitly not ignored
+     * @listens {$notifications.registered} listen event to start push notification management for chat which requested it.
+     * @listens {$notifications.received} listen event to mark received notification as `seen` (if `configuration.markAsSeen` is set to `true`).
+     * @listens {$created.chat} listen event to enable push notifications on just created chat if it explicitly not ignored
      *     (`configuration.ignoredChats`).
-     * @listens {$.notifications.connected} listen event to enable push notifications on chat if it explicitly not ignored
+     * @listens {$notifications.connected} listen event to enable push notifications on chat if it explicitly not ignored
      *     (`configuration.ignoredChats`).
-     * @listens {$.notifications.disconnected} listen event to disable push notifications on chat.
+     * @listens {$notifications.disconnected} listen event to disable push notifications on chat.
      * @example <caption>Simple setup</caption>
      * import { plugin } from 'chat-engine-notifications';
      *
@@ -167,9 +167,9 @@ export class CENotificationsExtension extends ChatEnginePlugin {
     construct() {
         /** @type CENotifications */
         this.parent.notifications = this.notifications;
-        this.parent.notifications.on('$.notifications.registered', this._onDeviceRegister);
+        this.parent.notifications.on('$notifications.registered', this._onDeviceRegister);
         if (this.configuration.markAsSeen) {
-            this.parent.notifications.on('$.notifications.received', this._onNotification);
+            this.parent.notifications.on('$notifications.received', this._onNotification);
         }
         this.ChatEngine.on('$.created.chat', this._onChatCreate);
         this.ChatEngine.on('$.connected', this._onChatConnect);
@@ -186,9 +186,9 @@ export class CENotificationsExtension extends ChatEnginePlugin {
         destructingInstances.push(this);
 
         // Stop listening events from other modules.
-        this.parent.notifications.off('$.notifications.registered', this._onDeviceRegister);
+        this.parent.notifications.off('$notifications.registered', this._onDeviceRegister);
         if (this.configuration.markAsSeen) {
-            this.parent.notifications.off('$.notifications.received', this._onNotification);
+            this.parent.notifications.off('$notifications.received', this._onNotification);
         }
         this.ChatEngine.off('$.created.chat', this._onChatCreate);
         this.ChatEngine.off('$.connected', this._onChatConnect);
@@ -241,10 +241,10 @@ export class CENotificationsExtension extends ChatEnginePlugin {
         }
 
         if (TypeValidator.isDefined(notification.notification.cepayload) && (notification.userInteraction || notification.foreground)) {
-            const { ceid, event } = notification.notification.cepayload;
-            if (TypeValidator.isDefined(ceid) && event !== '$.notifications.seen') {
-                this.parent.notifications.emit('$.notifications.seen');
-                this.ChatEngine.me.direct.emit('$.notifications.seen', { ceid });
+            const { eid, event } = notification.notification.cepayload;
+            if (TypeValidator.isDefined(eid) && event !== '$notifications.seen') {
+                this.parent.notifications.emit('$notifications.seen');
+                this.ChatEngine.me.direct.emit('$notifications.seen', { eid });
             }
         }
     }
@@ -254,8 +254,8 @@ export class CENotificationsExtension extends ChatEnginePlugin {
      * @private
      */
     markAllNotificationAsSeen() {
-        this.parent.notifications.emit('$.notifications.seen');
-        this.ChatEngine.me.direct.emit('$.notifications.seen', { ceid: 'all' });
+        this.parent.notifications.emit('$notifications.seen');
+        this.ChatEngine.me.direct.emit('$notifications.seen', { eid: 'all' });
     }
 
     /**
@@ -359,7 +359,7 @@ export class CENotificationsExtension extends ChatEnginePlugin {
         payload.data = payload.data || {};
 
         // Mark notification as seen event.
-        if (event === '$.notifications.seen') {
+        if (event === '$notifications.seen') {
             formattedPayload = CENotificationFormatter.seenNotification(payload, this.configuration.platforms);
             next(null, CENotificationFormatter.normalized(payload, formattedPayload));
             return;
@@ -376,9 +376,10 @@ export class CENotificationsExtension extends ChatEnginePlugin {
                 chat: payload.chat.channel,
                 data: payload.data
             };
+
             this.parent.notifications.formatNotificationPayload(nativePayload, (nativeFormattedPayload, canFormat) => {
                 if (!canFormat || nativeFormattedPayload === null) {
-                    formattedPayload = CENotificationFormatter.notifications(payload, this.configuration.platforms);
+                    formattedPayload = CENotificationFormatter.notifications(payload, this.configuration.platforms, this.configuration.messageKey);
                 } else {
                     formattedPayload = nativeFormattedPayload;
                 }
@@ -528,8 +529,8 @@ export class CENotificationsExtension extends ChatEnginePlugin {
         }
 
         // Add additional event to list of events which should be pre-processed before sending.
-        if (!configuration.events.includes('$.notifications.seen')) {
-            configuration.events.push('$.notifications.seen');
+        if (!configuration.events.includes('$notifications.seen')) {
+            configuration.events.push('$notifications.seen');
         }
     }
 

--- a/src/components/notifications.js
+++ b/src/components/notifications.js
@@ -237,7 +237,7 @@ export default class CENotifications extends EventEmitter2 {
 
     /**
      * Try to retrieve push notification payload which has been used to launch application.
-     * If any remote notification has been used to open application it will be sent along with `$.notifications.received` event.
+     * If any remote notification has been used to open application it will be sent along with `$notifications.received` event.
      *
      * @example <caption>Request for initial notification</caption>
      * import { plugin } from 'chat-engine-notifications';
@@ -250,7 +250,7 @@ export default class CENotifications extends EventEmitter2 {
      * // Since plugin extend Me, it first should be initialized with Chat Engine connection. As soon as Chat Engine connect user, it will issue
      * // '$.ready' event.
      * ChatEngine.on('$.ready', () => {
-     *     ChatEngine.me.notifications.on('$.notifications.received', notification => {
+     *     ChatEngine.me.notifications.on('$notifications.received', notification => {
      *          // Initial messages delivered with 'foreground' set to 'false'.
      *         if (!notification.foreground) {
      *             console.log(`Received initial notification: ${JSON.stringify(notification.notification)}`);
@@ -336,11 +336,11 @@ export default class CENotifications extends EventEmitter2 {
      * @param {Object} token - Received device push token information object.
      * @param {String} token.deviceToken - Reference on actual device push token which should be used with chat channels registration API.
      *
-     * @emits {$.notifications.registered} emit event when native module reported back what device did receive notification token.
+     * @emits {$notifications.registered} emit event when native module reported back what device did receive notification token.
      * @private
      */
     onRegister(token) {
-        this.emit('$.notifications.registered', token.deviceToken);
+        this.emit('$notifications.registered', token.deviceToken);
     }
 
     /**
@@ -348,18 +348,18 @@ export default class CENotifications extends EventEmitter2 {
      *
      * @param {Object} error - Received registration error explanation.
      *
-     * @emits {$.notifications.registration.fail} emit event when native module reported back what device registration did fail.
+     * @emits {$notifications.registration.fail} emit event when native module reported back what device registration did fail.
      * @private
      */
     onRegistrationFail(error) {
-        this.emit('$.notifications.registration.fail', error);
+        this.emit('$notifications.registration.fail', error);
     }
 
     /**
      * Handle incoming push notification.
      *
      * @param {CENNotificationPayload} payload - Reference on object which contain information about pushed data and completion callback (if passed).
-     * @emits {$.notifications.received} emit when device receive new remote notification sent by **PubNub** service on request of remote user.
+     * @emits {$notifications.received} emit when device receive new remote notification sent by **PubNub** service on request of remote user.
      *
      * @throws {TypeError} in case if passed `notification` is not type of _object_ or empty.
      * @private
@@ -377,6 +377,6 @@ export default class CENotifications extends EventEmitter2 {
         } else if (TypeValidator.isTypeOf(payload.completion, 'function')) {
             payload.completion('noData');
         }
-        this.emit('$.notifications.received', payload);
+        this.emit('$notifications.received', payload);
     }
 }

--- a/src/helpers/formatter.js
+++ b/src/helpers/formatter.js
@@ -54,10 +54,11 @@ export default class CENotificationFormatter {
      *
      * @param {ChatEngineEventPayload} eventPayload - Reference on payload which has been emitted with {@link Event}.
      * @param {CEPlatforms} platforms - Reference on list of platforms for which payload should be composed.
+     * @param {String} [messageKey='message'] - Name of key under which stored published message, which should be handled by default formatter.
      * @return {Object} Reference on modified {@link Event} payload which include keys required to trigger remote notification sending for requested
      *     {@link CEPlatforms}.
      */
-    static notifications(eventPayload, platforms) {
+    static notifications(eventPayload, platforms, messageKey = 'message') {
         if (!CENotificationFormatter.verifyChatEnginePayload(eventPayload)) {
             return {};
         }
@@ -75,7 +76,7 @@ export default class CENotificationFormatter {
         let notificationCategory = null;
         if (eventPayload.event === 'message') {
             notificationTitle = `${eventPayload.sender} send message in ${chatName}`;
-            notificationBody = eventPayload.data.message;
+            notificationBody = eventPayload.data[messageKey];
             notificationTicker = 'New chat message';
             notificationCategory = CENNotifications.CATEGORY_MESSAGE;
         } else if (eventPayload.event === '$.invite') {
@@ -123,8 +124,8 @@ export default class CENotificationFormatter {
         if (!CENotificationFormatter.verifyChatEnginePayload(payload)) {
             return {};
         }
-        if (!TypeValidator.isDefined(payload.data.ceid) || !TypeValidator.sequence(payload.data.ceid, [['isTypeOf', String], 'notEmpty'])) {
-            throwError(new TypeError('Unexpected CEID: empty or has unexpected type (string expected).'));
+        if (!TypeValidator.isDefined(payload.data.eid) || !TypeValidator.sequence(payload.data.eid, [['isTypeOf', String], 'notEmpty'])) {
+            throwError(new TypeError('Unexpected EID: empty or has unexpected type (string expected).'));
             return {};
         }
 
@@ -163,7 +164,7 @@ export default class CENotificationFormatter {
             chat: eventPayload.chat.channel,
             event: eventPayload.event,
             data: eventPayload.data,
-            ceid: uuidv4(),
+            eid: uuidv4(),
             category
         };
 

--- a/src/helpers/formatter.js
+++ b/src/helpers/formatter.js
@@ -28,7 +28,7 @@ export default class CENotificationFormatter {
             throwError(new TypeError('Unexpected event: empty or has unexpected data type (string expected).'));
             return null;
         }
-        return `com.pubnub.chat-engine.${event.indexOf('$.') === 0 ? event.slice(2) : event}`;
+        return `com.pubnub.chat-engine.${event.indexOf('$') === 0 ? event.slice(event.indexOf('.') === 1 ? 2 : 1) : event}`;
     }
 
     /**

--- a/src/helpers/types/index.js
+++ b/src/helpers/types/index.js
@@ -10,8 +10,9 @@
  * @typedef {Object} CEConfiguration
  * @property {!String[]} events - List of events for which push notification payload should be created.
  * @property {String[]} [ignoredChats='#read.#feed'] - List of chats for which it is not required to register on push notifications.
+ * @property {String} [messageKey='message'] - Name of key under which stored published message, which should be handled by default formatter.
  * @property {!CEPlatforms} platforms Available platforms for push notification should be constructed when {@link ChatEngine} send events.
- * @property {Boolean} [markAsSeen=true] - Whether received notification should be marked as `seen` or not when received (when `$.notification` event
+ * @property {Boolean} [markAsSeen=true] - Whether received notification should be marked as `seen` or not when received (when `$notification` event
  *     is sent).
  * @property {CEFormatterCallback} [formatter] - Called each time when {@link ChatEngine} is about to send one of tracked `events` make layout
  *     formatting for notification.

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-unused-expressions,no-new,no-new-wrappers,no-new-object,no-array-constructor */
-/* global test, expect */
+/* global test, expect, jasmine */
 import ChatEngineCore from 'chat-engine';
 import { plugin } from '../../src/plugin';
 
@@ -34,7 +34,12 @@ describe('integration::ChatEngineNotifications', () => {
     let chatEngine;
 
     beforeEach(() => {
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
         chatEngine = ChatEngineCore.create({ publishKey: process.env.PUBLISH_KEY, subscribeKey: process.env.SUBSCRIBE_KEY });
+    });
+
+    afterEach(() => {
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000;
     });
 
     test('should add \'notifications\' property to Me', (done) => {

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -174,26 +174,26 @@ describe('integration::ChatEngineNotifications', () => {
         chatEngine.connect('pubnub', { works: true }, 'pubnub-secret');
     });
 
-    test('should send $.notifications.seen event', (done) => {
-        const notification = { notification: { aps: { alert: 'PubNub is awesome!' }, cepayload: { ceid: 'unique' } }, foreground: true };
+    test('should send $notifications.seen event', (done) => {
+        const notification = { notification: { aps: { alert: 'PubNub is awesome!' }, cepayload: { eid: 'unique' } }, foreground: true };
         let messageReceived = false;
         chatEngine.proto('Me', plugin({ events: ['$.invite', 'message'], platforms: { ios: true, android: true }, ignoredChats }));
         chatEngine.on('$.ready', () => {
             const messageHandler = (message) => {
                 messageReceived = true;
-                chatEngine.me.direct.off('$.notifications.seen', messageHandler);
+                chatEngine.me.direct.off('$notifications.seen', messageHandler);
                 expect(message.pn_apns).toBeDefined();
                 expect(message.pn_apns.cepayload).toBeDefined();
-                expect(message.pn_apns.cepayload.data.ceid).toEqual(notification.notification.cepayload.ceid);
+                expect(message.pn_apns.cepayload.data.eid).toEqual(notification.notification.cepayload.eid);
                 expect(message.pn_gcm).toBeDefined();
                 expect(message.pn_gcm.data.cepayload).toBeDefined();
-                expect(message.pn_gcm.data.cepayload.data.ceid).toEqual(notification.notification.cepayload.ceid);
+                expect(message.pn_gcm.data.cepayload.data.eid).toEqual(notification.notification.cepayload.eid);
                 jest.clearAllTimers();
                 done();
             };
             const connectionHandler = () => {
                 chatEngine.me.direct.off('$.connected', connectionHandler);
-                chatEngine.me.direct.on('$.notifications.seen', messageHandler);
+                chatEngine.me.direct.on('$notifications.seen', messageHandler);
                 chatEngine.me.notifications.markNotificationAsSeen(notification);
                 let retryInterval = setInterval(() => {
                     if (!messageReceived) {

--- a/test/unit/components/extension.test.js
+++ b/test/unit/components/extension.test.js
@@ -820,7 +820,8 @@ describe('unittest::CENotificationsExtension', () => {
                 expect(notificationsSpy).toHaveBeenCalledWith(
                     inviteEvent,
                     extension.configuration.platforms,
-                    extension.configuration.messageKey);
+                    extension.configuration.messageKey
+                );
                 expect(next).toHaveBeenCalled();
                 done();
             });
@@ -835,7 +836,8 @@ describe('unittest::CENotificationsExtension', () => {
                 expect(notificationsSpy).toHaveBeenCalledWith(
                     inviteEvent,
                     extension.configuration.platforms,
-                    extension.configuration.messageKey);
+                    extension.configuration.messageKey
+                );
                 expect(next).toHaveBeenCalled();
                 done();
             });

--- a/test/unit/components/extension.test.js
+++ b/test/unit/components/extension.test.js
@@ -62,7 +62,7 @@ describe('unittest::CENotificationsExtension', () => {
             expect(extension.notificationToken).toBeNull();
             expect(extension.chatsState).toEqual({});
             expect(extension.configuration.ignoredChats.includes('#read.#feed')).toBeTruthy();
-            expect(extension.configuration.events.includes('$.notifications.seen')).toBeTruthy();
+            expect(extension.configuration.events.includes('$notifications.seen')).toBeTruthy();
             expect(extension.destructing).toBeFalsy();
         });
 
@@ -249,18 +249,18 @@ describe('unittest::CENotificationsExtension', () => {
             extension.construct();
             const registeredEvents = onSpy.mock.calls.map(event => event[0]);
             expect(onSpy.mock.calls).toHaveLength(1);
-            expect(registeredEvents.includes('$.notifications.registered')).toBeTruthy();
-            expect(registeredEvents.includes('$.notifications.received')).toBeFalsy();
+            expect(registeredEvents.includes('$notifications.registered')).toBeTruthy();
+            expect(registeredEvents.includes('$notifications.received')).toBeFalsy();
             onSpy.mockRestore();
         });
 
-        test('should subscribe on \'$.notifications.received\' if markAsSeen is set to true', () => {
+        test('should subscribe on \'$notifications.received\' if markAsSeen is set to true', () => {
             extension.configuration.markAsSeen = true;
             const onSpy = jest.spyOn(extension.notifications, 'on');
             extension.construct();
             const registeredEvents = onSpy.mock.calls.map(event => event[0]);
             expect(onSpy.mock.calls).toHaveLength(2);
-            expect(registeredEvents.includes('$.notifications.received')).toBeTruthy();
+            expect(registeredEvents.includes('$notifications.received')).toBeTruthy();
             onSpy.mockRestore();
         });
 
@@ -396,30 +396,30 @@ describe('unittest::CENotificationsExtension', () => {
         });
 
         test('should be called when \'notifications.markNotificationAsSeen\' is used', () => {
-            const notification = { notification: { aps: { alert: 'PubNub is awesome!' }, cepayload: { ceid: 'unique' } }, foreground: true };
+            const notification = { notification: { aps: { alert: 'PubNub is awesome!' }, cepayload: { eid: 'unique' } }, foreground: true };
             const onSpy = jest.spyOn(extension.ChatEngine.me.direct, 'emit');
             extension.notifications.markNotificationAsSeen(notification);
             expect(onSpy).toHaveBeenCalled();
             onSpy.mockRestore();
         });
 
-        test('should emit \'$.notifications.seen\' event to user\'s direct chat', () => {
-            const notification = { notification: { aps: { alert: 'PubNub is awesome!' }, cepayload: { ceid: 'unique' } }, foreground: true };
+        test('should emit \'$notifications.seen\' event to user\'s direct chat', () => {
+            const notification = { notification: { aps: { alert: 'PubNub is awesome!' }, cepayload: { eid: 'unique' } }, foreground: true };
             const onSpy = jest.spyOn(extension.ChatEngine.me.direct, 'emit');
             extension.markNotificationAsSeen(notification);
-            expect(onSpy).toHaveBeenCalledWith('$.notifications.seen', { ceid: notification.notification.cepayload.ceid });
+            expect(onSpy).toHaveBeenCalledWith('$notifications.seen', { eid: notification.notification.cepayload.eid });
             onSpy.mockRestore();
         });
 
-        test('should emit \'$.notifications.seen\' event on behalf of \'notifications\' instance', () => {
-            const notification = { notification: { aps: { alert: 'PubNub is awesome!' }, cepayload: { ceid: 'unique' } }, foreground: true };
+        test('should emit \'$notifications.seen\' event on behalf of \'notifications\' instance', () => {
+            const notification = { notification: { aps: { alert: 'PubNub is awesome!' }, cepayload: { eid: 'unique' } }, foreground: true };
             const onSpy = jest.spyOn(extension.parent.notifications, 'emit');
             extension.markNotificationAsSeen(notification);
-            expect(onSpy).toHaveBeenCalledWith('$.notifications.seen');
+            expect(onSpy).toHaveBeenCalledWith('$notifications.seen');
             onSpy.mockRestore();
         });
 
-        test('should not emit \'$.notifications.seen\' event if \'cepayload\' is missing', () => {
+        test('should not emit \'$notifications.seen\' event if \'cepayload\' is missing', () => {
             const notification = { notification: { aps: { alert: 'PubNub is awesome!' } }, foreground: true };
             const onSpy = jest.spyOn(extension.ChatEngine.me.direct, 'emit');
             extension.markNotificationAsSeen(notification);
@@ -427,11 +427,11 @@ describe('unittest::CENotificationsExtension', () => {
             onSpy.mockRestore();
         });
 
-        test('should not emit \'$.notifications.seen\' event if notification not from user interaction or not in foreground', () => {
+        test('should not emit \'$notifications.seen\' event if notification not from user interaction or not in foreground', () => {
             const notification = {
                 notification: {
                     aps: { alert: 'PubNub is awesome!' },
-                    cepayload: { ceid: 'unique' }
+                    cepayload: { eid: 'unique' }
                 },
                 foreground: false,
                 userInteraction: false
@@ -442,7 +442,7 @@ describe('unittest::CENotificationsExtension', () => {
             onSpy.mockRestore();
         });
 
-        test('should not emit \'$.notifications.seen\' event when \'ceid\' is missing', () => {
+        test('should not emit \'$notifications.seen\' event when \'eid\' is missing', () => {
             const notification = { notification: { aps: { alert: 'PubNub is awesome!' }, cepayload: { } }, foreground: true };
             const onSpy = jest.spyOn(extension.ChatEngine.me.direct, 'emit');
             extension.markNotificationAsSeen(notification);
@@ -450,9 +450,9 @@ describe('unittest::CENotificationsExtension', () => {
             onSpy.mockRestore();
         });
 
-        test('should not emit \'$.notifications.seen\' event when notification\'s \'event\' is set to \'$.notifications.seen\'', () => {
+        test('should not emit \'$notifications.seen\' event when notification\'s \'event\' is set to \'$notifications.seen\'', () => {
             const notification = {
-                notification: { aps: { alert: 'PubNub is awesome!' }, cepayload: { event: '$.notifications.seen' } },
+                notification: { aps: { alert: 'PubNub is awesome!' }, cepayload: { event: '$notifications.seen' } },
                 foreground: true
             };
             const onSpy = jest.spyOn(extension.ChatEngine.me.direct, 'emit');
@@ -501,17 +501,17 @@ describe('unittest::CENotificationsExtension', () => {
             onSpy.mockRestore();
         });
 
-        test('should emit \'$.notifications.seen\' event to user\'s direct chat', () => {
+        test('should emit \'$notifications.seen\' event to user\'s direct chat', () => {
             const onSpy = jest.spyOn(extension.ChatEngine.me.direct, 'emit');
             extension.markAllNotificationAsSeen();
-            expect(onSpy).toHaveBeenCalledWith('$.notifications.seen', { ceid: 'all' });
+            expect(onSpy).toHaveBeenCalledWith('$notifications.seen', { eid: 'all' });
             onSpy.mockRestore();
         });
 
-        test('should emit \'$.notifications.seen\' event on behalf of \'notifications\' instance', () => {
+        test('should emit \'$notifications.seen\' event on behalf of \'notifications\' instance', () => {
             const onSpy = jest.spyOn(extension.parent.notifications, 'emit');
             extension.markAllNotificationAsSeen();
-            expect(onSpy).toHaveBeenCalledWith('$.notifications.seen');
+            expect(onSpy).toHaveBeenCalledWith('$notifications.seen');
             onSpy.mockRestore();
         });
     });
@@ -717,7 +717,7 @@ describe('unittest::CENotificationsExtension', () => {
         test('should call formatter on event\'s middleware execution', () => {
             const notificationFormatterSpy = jest.spyOn(extension, 'notificationFormatter').mockImplementation(() => {});
             const middleware = extension.chatMiddlewareExtension();
-            middleware.middleware.emit['$.notifications.seen']();
+            middleware.middleware.emit['$notifications.seen']();
             expect(notificationFormatterSpy).toHaveBeenCalled();
             notificationFormatterSpy.mockRestore();
         });
@@ -743,13 +743,13 @@ describe('unittest::CENotificationsExtension', () => {
             expect(typeof extension.notificationFormatter === 'function').toBeTruthy();
         });
 
-        test('should build notification for \'$.notifications.seen\'', () => {
+        test('should build notification for \'$notifications.seen\'', () => {
             const notification = Object.assign({}, inviteEvent);
             delete notification.data;
             const seenNotificationSpy = jest.spyOn(CENotificationFormatter, 'seenNotification').mockImplementation(() => ({}));
             const normalizedSpy = jest.spyOn(CENotificationFormatter, 'normalized').mockImplementation(() => ({}));
             const next = jest.fn();
-            extension.notificationFormatter('$.notifications.seen', notification, next);
+            extension.notificationFormatter('$notifications.seen', notification, next);
             expect(seenNotificationSpy).toHaveBeenCalled();
             expect(next).toHaveBeenCalled();
             normalizedSpy.mockRestore();
@@ -763,7 +763,7 @@ describe('unittest::CENotificationsExtension', () => {
 
             extension.notificationFormatter(inviteEvent.event, inviteEvent, next);
             const expected = CENotificationFormatter.normalized(inviteEvent, formattedPayload);
-            expected.pn_apns.cepayload.ceid = next.mock.calls[0][1].pn_apns.cepayload.ceid;
+            expected.pn_apns.cepayload.eid = next.mock.calls[0][1].pn_apns.cepayload.eid;
 
             expect(extension.configuration.formatter).toHaveBeenCalledWith(inviteEvent);
             expect(next).toHaveBeenCalledWith(null, expected);
@@ -786,7 +786,7 @@ describe('unittest::CENotificationsExtension', () => {
                 callback(formattedPayload, true);
 
                 const expected = CENotificationFormatter.normalized(inviteEvent, formattedPayload);
-                expected.pn_apns.cepayload.ceid = next.mock.calls[0][1].pn_apns.cepayload.ceid;
+                expected.pn_apns.cepayload.eid = next.mock.calls[0][1].pn_apns.cepayload.eid;
 
                 expect(formatNotificationPayloadSpy).toHaveBeenCalledWith(nativeInvitePayload, expect.any(Function));
                 expect(next).toHaveBeenCalledWith(null, expected);
@@ -803,7 +803,7 @@ describe('unittest::CENotificationsExtension', () => {
                 callback(formattedPayload, true);
 
                 const expected = CENotificationFormatter.normalized(inviteEvent, formattedPayload);
-                expected.pn_apns.cepayload.ceid = next.mock.calls[0][1].pn_apns.cepayload.ceid;
+                expected.pn_apns.cepayload.eid = next.mock.calls[0][1].pn_apns.cepayload.eid;
 
                 expect(formatNotificationPayloadSpy).toHaveBeenCalledWith(nativeInvitePayload, expect.any(Function));
                 expect(next).toHaveBeenCalledWith(null, expected);
@@ -854,7 +854,7 @@ describe('unittest::CENotificationsExtension', () => {
             expect(typeof extension.onDeviceRegister === 'function').toBeTruthy();
         });
 
-        test('should be called in response on \'$.notifications.registered\' event', (done) => {
+        test('should be called in response on \'$notifications.registered\' event', (done) => {
             const tokenData = { deviceToken: '00000000000000000000000000000000' };
             const onDeviceRegisterSpy = jest.spyOn(extension, 'onDeviceRegister').mockImplementation(() => {
                 expect(onDeviceRegisterSpy).toHaveBeenCalledWith(tokenData.deviceToken);
@@ -1001,14 +1001,14 @@ describe('unittest::CENotificationsExtension', () => {
             expect(typeof extension.onNotification === 'function').toBeTruthy();
         });
 
-        test('should be called in response on \'$.notifications.received\' event if markAsSeen set to true', () => {
+        test('should be called in response on \'$notifications.received\' event if markAsSeen set to true', () => {
             configuration = Object.assign({ markAsSeen: true }, minimumConfiguration);
             extension = createExtensionWithConfiguration(configuration);
             const notification = { PubNub: 'is awesome!' };
             const onNotificationSpy = jest.spyOn(extension, 'onNotification');
             const markNotificationAsSeenSpy = jest.spyOn(extension.notifications, 'markNotificationAsSeen').mockImplementation(() => ({}));
 
-            extension.notifications.emit('$.notifications.received', notification);
+            extension.notifications.emit('$notifications.received', notification);
 
             expect(onNotificationSpy).toHaveBeenCalledWith(notification);
             expect(markNotificationAsSeenSpy).toHaveBeenCalledWith(notification);
@@ -1016,10 +1016,10 @@ describe('unittest::CENotificationsExtension', () => {
             markNotificationAsSeenSpy.mockRestore();
         });
 
-        test('should not call in response on \'$.notifications.received\' event if markAsSeen set to false', () => {
+        test('should not call in response on \'$notifications.received\' event if markAsSeen set to false', () => {
             const notification = { PubNub: 'is awesome!' };
             const onNotificationSpy = jest.spyOn(extension, 'onNotification');
-            extension.notifications.emit('$.notifications.received', notification);
+            extension.notifications.emit('$notifications.received', notification);
             expect(onNotificationSpy).not.toHaveBeenCalled();
             onNotificationSpy.mockRestore();
         });
@@ -1207,8 +1207,8 @@ describe('unittest::CENotificationsExtension', () => {
             expect(testedConfiguration.ignoredChats).toHaveLength(0);
         });
 
-        test('should not add \'$.notifications.seen\' duplicates into in \'configuration.events\'', () => {
-            const testedConfiguration = { events: ['$.notifications.seen'] };
+        test('should not add \'$notifications.seen\' duplicates into in \'configuration.events\'', () => {
+            const testedConfiguration = { events: ['$notifications.seen'] };
             CENotificationsExtension.applyDefaultConfigurationValues(testedConfiguration);
             CENotificationsExtension.applyDefaultConfigurationValues(testedConfiguration);
             testedConfiguration.events.pop();

--- a/test/unit/components/extension.test.js
+++ b/test/unit/components/extension.test.js
@@ -817,7 +817,10 @@ describe('unittest::CENotificationsExtension', () => {
             const next = jest.fn();
             NativeModules.CENNotifications.formatNotificationPayload = jest.fn((nativePayload, callback) => {
                 callback(null, false);
-                expect(notificationsSpy).toHaveBeenCalledWith(inviteEvent, extension.configuration.platforms);
+                expect(notificationsSpy).toHaveBeenCalledWith(
+                    inviteEvent,
+                    extension.configuration.platforms,
+                    extension.configuration.messageKey);
                 expect(next).toHaveBeenCalled();
                 done();
             });
@@ -829,7 +832,10 @@ describe('unittest::CENotificationsExtension', () => {
             const next = jest.fn();
             NativeModules.CENNotifications.formatNotificationPayload = jest.fn((nativePayload, callback) => {
                 callback(null, true);
-                expect(notificationsSpy).toHaveBeenCalledWith(inviteEvent, extension.configuration.platforms);
+                expect(notificationsSpy).toHaveBeenCalledWith(
+                    inviteEvent,
+                    extension.configuration.platforms,
+                    extension.configuration.messageKey);
                 expect(next).toHaveBeenCalled();
                 done();
             });

--- a/test/unit/components/notifications.test.js
+++ b/test/unit/components/notifications.test.js
@@ -541,11 +541,11 @@ describe('unittest::CENotifications', () => {
             onRegisterSpy.mockRestore();
         });
 
-        test('should emit \'$.notifications.registered\' event in response on \'CENRegistered\' event', () => {
+        test('should emit \'$notifications.registered\' event in response on \'CENRegistered\' event', () => {
             const token = { deviceToken: '00000000000000000000000000000000' };
             const emitSpy = jest.spyOn(notifications, 'emit');
             DeviceEventEmitter.emit('CENRegistered', token);
-            expect(emitSpy).toHaveBeenCalledWith('$.notifications.registered', token.deviceToken);
+            expect(emitSpy).toHaveBeenCalledWith('$notifications.registered', token.deviceToken);
             emitSpy.mockRestore();
         });
     });
@@ -568,11 +568,11 @@ describe('unittest::CENotifications', () => {
             onRegistrationFailSpy.mockRestore();
         });
 
-        test('should emit \'$.notifications.registration.fail\' event in response on \'CENRegistered\' event', () => {
+        test('should emit \'$notifications.registration.fail\' event in response on \'CENRegistered\' event', () => {
             const error = { message: 'User didn\'t granted notifications usage.' };
             const emitSpy = jest.spyOn(notifications, 'emit');
             DeviceEventEmitter.emit('CENFailedToRegister', error);
-            expect(emitSpy).toHaveBeenCalledWith('$.notifications.registration.fail', error);
+            expect(emitSpy).toHaveBeenCalledWith('$notifications.registration.fail', error);
             emitSpy.mockRestore();
         });
     });
@@ -609,11 +609,11 @@ describe('unittest::CENotifications', () => {
             onNotificationSpy.mockRestore();
         });
 
-        test('should emit \'$.notifications.registration.fail\' event in response on \'CENRegistered\' event', () => {
+        test('should emit \'$notifications.registration.fail\' event in response on \'CENRegistered\' event', () => {
             const notification = { PubNub: ['is', 'awesome!'], action: {} };
             const emitSpy = jest.spyOn(notifications, 'emit');
             DeviceEventEmitter.emit('CENReceivedRemoteNotification', notification);
-            expect(emitSpy).toHaveBeenCalledWith('$.notifications.received', notification);
+            expect(emitSpy).toHaveBeenCalledWith('$notifications.received', notification);
             emitSpy.mockRestore();
         });
 

--- a/test/unit/helpers/formatter.test.js
+++ b/test/unit/helpers/formatter.test.js
@@ -34,8 +34,8 @@ describe('unittest::CENotificationFormatter', () => {
     const seenEventPayload = {
         chat: { channel: 'direct' },
         sender: 'PubNub',
-        event: '$.notifications.seen',
-        data: { ceid: 'unique-id' }
+        event: '$notifications.seen',
+        data: { eid: 'unique-id' }
     };
 
     describe('#category', () => {
@@ -47,8 +47,8 @@ describe('unittest::CENotificationFormatter', () => {
             expect(CENotificationFormatter.category('$.leave')).toEqual('com.pubnub.chat-engine.leave');
         });
 
-        test('should return category for \'$.notifications.received\' event', () => {
-            expect(CENotificationFormatter.category('$.notifications.received')).toEqual('com.pubnub.chat-engine.notifications.received');
+        test('should return category for \'$notifications.received\' event', () => {
+            expect(CENotificationFormatter.category('$notifications.received')).toEqual('com.pubnub.chat-engine.notifications.received');
         });
 
         test('should return category for \'message\' event', () => {
@@ -213,7 +213,7 @@ describe('unittest::CENotificationFormatter', () => {
             expect(notificationPayload.apns.aps['content-available']).toBeDefined();
             expect(notificationPayload.apns.cepayload).toBeDefined();
             expect(notificationPayload.apns.cepayload.data).toBeDefined();
-            expect(notificationPayload.apns.cepayload.data.ceid).toBeDefined();
+            expect(notificationPayload.apns.cepayload.data.eid).toBeDefined();
             expect(notificationPayload.gcm).not.toBeDefined();
         });
 
@@ -222,7 +222,7 @@ describe('unittest::CENotificationFormatter', () => {
             expect(TypeValidator.notEmpty(notificationPayload)).toBeTruthy();
             expect(notificationPayload.gcm.data.cepayload).toBeDefined();
             expect(notificationPayload.gcm.data.cepayload.data).toBeDefined();
-            expect(notificationPayload.gcm.data.cepayload.data.ceid).toBeDefined();
+            expect(notificationPayload.gcm.data.cepayload.data.eid).toBeDefined();
             expect(notificationPayload.apns).not.toBeDefined();
         });
 
@@ -241,7 +241,7 @@ describe('unittest::CENotificationFormatter', () => {
                 .toThrowError(/Unexpected payload: not defined or has unexpected type \(Object expected\)/);
         });
 
-        test('should not throw if CEID is \'undefined\' in non-test environment', () => {
+        test('should not throw if EID is \'undefined\' in non-test environment', () => {
             const payload = Object.assign({}, seenEventPayload, { data: { } });
             const originalNodeEnv = process.env.NODE_ENV;
             process.env.NODE_ENV = 'production';
@@ -252,22 +252,22 @@ describe('unittest::CENotificationFormatter', () => {
             process.env.NODE_ENV = originalNodeEnv;
         });
 
-        test('should throw TypeError when \'payload.data.ceid\' is \'undefined\'', () => {
+        test('should throw TypeError when \'payload.data.eid\' is \'undefined\'', () => {
             const payload = Object.assign({}, seenEventPayload, { data: { } });
             expect(() => CENotificationFormatter.seenNotification(payload))
-                .toThrowError(/Unexpected CEID: empty or has unexpected type \(string expected\)/);
+                .toThrowError(/Unexpected EID: empty or has unexpected type \(string expected\)/);
         });
 
-        test('should throw TypeError when \'payload.data.ceid\' is not type of String', () => {
-            const payload = Object.assign({}, seenEventPayload, { data: { ceid: 2010 } });
+        test('should throw TypeError when \'payload.data.eid\' is not type of String', () => {
+            const payload = Object.assign({}, seenEventPayload, { data: { eid: 2010 } });
             expect(() => CENotificationFormatter.seenNotification(payload))
-                .toThrowError(/Unexpected CEID: empty or has unexpected type \(string expected\)/);
+                .toThrowError(/Unexpected EID: empty or has unexpected type \(string expected\)/);
         });
 
-        test('should throw TypeError when \'payload.data.ceid\' is empty String', () => {
-            const payload = Object.assign({}, seenEventPayload, { data: { ceid: '' } });
+        test('should throw TypeError when \'payload.data.eid\' is empty String', () => {
+            const payload = Object.assign({}, seenEventPayload, { data: { eid: '' } });
             expect(() => CENotificationFormatter.seenNotification(payload))
-                .toThrowError(/Unexpected CEID: empty or has unexpected type \(string expected\)/);
+                .toThrowError(/Unexpected EID: empty or has unexpected type \(string expected\)/);
         });
     });
 
@@ -285,8 +285,8 @@ describe('unittest::CENotificationFormatter', () => {
         test('should not change passed \'cepayload\' content for iOS', () => {
             const originalPlatform = Platform.OS;
             Platform.OS = 'ios';
-            const notification = { apns: { aps: { }, cepayload: { some: 'fun', data: { ceid: 'cool' } } } };
-            const expected = { apns: { aps: { }, cepayload: { some: 'fun', data: { ceid: 'cool' } } } };
+            const notification = { apns: { aps: { }, cepayload: { some: 'fun', data: { eid: 'cool' } } } };
+            const expected = { apns: { aps: { }, cepayload: { some: 'fun', data: { eid: 'cool' } } } };
             CENotificationFormatter.normalized(leaveEventPayload, notification);
 
             expect(notification.apns.cepayload).toBeDefined();
@@ -298,7 +298,7 @@ describe('unittest::CENotificationFormatter', () => {
         test('should use category from \'aps.category\' and not built from event for iOS', () => {
             const originalPlatform = Platform.OS;
             Platform.OS = 'ios';
-            const notification = { apns: { aps: { category: 'fun.category' }, cepayload: { some: 'fun', data: { ceid: 'cool' } } } };
+            const notification = { apns: { aps: { category: 'fun.category' }, cepayload: { some: 'fun', data: { eid: 'cool' } } } };
             const normalizedNotification = CENotificationFormatter.normalized(leaveEventPayload, notification);
 
             expect(normalizedNotification.pn_apns.aps.category).toEqual(notification.apns.aps.category);
@@ -310,7 +310,7 @@ describe('unittest::CENotificationFormatter', () => {
         test('should use category from \'cepayload.category\' and not built from event for iOS', () => {
             const originalPlatform = Platform.OS;
             Platform.OS = 'ios';
-            const notification = { apns: { aps: { }, cepayload: { category: 'fun.category', some: 'fun', data: { ceid: 'cool' } } } };
+            const notification = { apns: { aps: { }, cepayload: { category: 'fun.category', some: 'fun', data: { eid: 'cool' } } } };
             const normalizedNotification = CENotificationFormatter.normalized(leaveEventPayload, notification);
 
             expect(normalizedNotification.pn_apns.aps.category).toEqual(notification.apns.cepayload.category);
@@ -335,7 +335,7 @@ describe('unittest::CENotificationFormatter', () => {
         test('should use category from \'data.category\' and not built from event for Android', () => {
             const originalPlatform = Platform.OS;
             Platform.OS = 'android';
-            const notification = { gcm: { data: { category: 'fun.category', cepayload: { some: 'fun', data: { ceid: 'cool' } } } } };
+            const notification = { gcm: { data: { category: 'fun.category', cepayload: { some: 'fun', data: { eid: 'cool' } } } } };
             const normalizedNotification = CENotificationFormatter.normalized(leaveEventPayload, notification);
 
             expect(normalizedNotification.pn_gcm.data.category).toEqual(notification.gcm.data.category);
@@ -347,7 +347,7 @@ describe('unittest::CENotificationFormatter', () => {
         test('should not add category from \'cepayload.category\' to \'data\' objet root for Android', () => {
             const originalPlatform = Platform.OS;
             Platform.OS = 'android';
-            const notification = { gcm: { data: { cepayload: { category: 'fun.category', some: 'fun', data: { ceid: 'cool' } } } } };
+            const notification = { gcm: { data: { cepayload: { category: 'fun.category', some: 'fun', data: { eid: 'cool' } } } } };
             const normalizedNotification = CENotificationFormatter.normalized(leaveEventPayload, notification);
 
             expect(normalizedNotification.pn_gcm.data.category).not.toBeDefined();
@@ -382,16 +382,16 @@ describe('unittest::CENotificationFormatter', () => {
             const notification = { apns: { aps: { alert: 'Notification' } } };
             const normalized = CENotificationFormatter.normalized(leaveEventPayload, Object.assign({}, notification));
             expect(TypeValidator.isTypeOf(normalized.pn_apns.cepayload, Object)).toBeTruthy();
-            expect(TypeValidator.isTypeOf(normalized.pn_apns.cepayload.ceid, String)).toBeTruthy();
-            expect(TypeValidator.notEmpty(normalized.pn_apns.cepayload.ceid)).toBeTruthy();
+            expect(TypeValidator.isTypeOf(normalized.pn_apns.cepayload.eid, String)).toBeTruthy();
+            expect(TypeValidator.notEmpty(normalized.pn_apns.cepayload.eid)).toBeTruthy();
         });
 
         test('should add notification String identifier for \'gcm\'', () => {
             const notification = { gcm: { notification: { title: 'Notification' } } };
             const normalized = CENotificationFormatter.normalized(leaveEventPayload, Object.assign({}, notification));
             expect(TypeValidator.isTypeOf(normalized.pn_gcm.data.cepayload, Object)).toBeTruthy();
-            expect(TypeValidator.isTypeOf(normalized.pn_gcm.data.cepayload.ceid, String)).toBeTruthy();
-            expect(TypeValidator.notEmpty(normalized.pn_gcm.data.cepayload.ceid)).toBeTruthy();
+            expect(TypeValidator.isTypeOf(normalized.pn_gcm.data.cepayload.eid, String)).toBeTruthy();
+            expect(TypeValidator.notEmpty(normalized.pn_gcm.data.cepayload.eid)).toBeTruthy();
         });
 
         test('should not throw if malformed payload provided in non-test environment', () => {


### PR DESCRIPTION
Added ability to specify name of key under which stored message, which should be used for automated formatting (`message` and `$.invite` events if no formatter provided).