### PR TITLE
ChatEngine Push Notification Plugin v1.1.2 Release

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "url": "https://github.com/pubnub/chat-engine-push-notifications/issues"
   },
   "homepage": "https://github.com/pubnub/chat-engine-push-notifications#readme",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "scripts": {
     "test": "jest --ci --forceExit",
     "unit_test": "jest --ci --forceExit --config=test/unit/jest-config.json --testPathPattern=test/unit/",


### PR DESCRIPTION
Looks like this one release will be too soon. 
Probably during previous releases one of version (1.1.1 has bee pushed w/o release merge pull request).
Bumping version to make it possible to push it to NPM registry.